### PR TITLE
Fix an encoding error on Windows

### DIFF
--- a/src/adzerk/boot_jar2bin.clj
+++ b/src/adzerk/boot_jar2bin.clj
@@ -87,7 +87,7 @@
               exe-fname  (str fname ".exe")
               xml-file   (io/file tgt xml-fname)
               out-file   (doto (io/file output-dir exe-fname) io/make-parents)]
-          (with-open [xml (FileWriter. xml-file)]
+          (with-open [xml (io/writer xml-file :encoding "UTF-8")]
             (write-launch4j-config {:jar-file     jar
                                     :out-file     out-file
                                     :main-class   main


### PR DESCRIPTION
This should fix the following error when writing the Launch4j exe configuration xml file (encountered this problem when trying to build the alda project on Windows with instructions given in this Github issue: https://github.com/alda-lang/alda-core/issues/31)

```
Writing pom.xml and pom.properties...
Adding uberjar entries...
Writing alda.jar...
Creating alda binary...
Writing E:\Workspace\Ohjelmointi\clojure\alda\build\alda...
Merge conflict: not adding alda
                              java.lang.Thread.run              Thread.java:  748
java.util.concurrent.ThreadPoolExecutor$Worker.run  ThreadPoolExecutor.java:  624
 java.util.concurrent.ThreadPoolExecutor.runWorker  ThreadPoolExecutor.java: 1149
               java.util.concurrent.FutureTask.run          FutureTask.java:  266
                                               ...
               clojure.core/binding-conveyor-fn/fn                 core.clj: 1938
                                 boot.core/boot/fn                 core.clj: 1031
                               boot.core/run-tasks                 core.clj: 1021
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  567
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  729
                    boot.task.built-in/fn/fn/fn/fn             built_in.clj:  864
              adzerk.boot-jar2bin/eval488/fn/fn/fn         boot_jar2bin.clj:   36
              adzerk.boot-jar2bin/eval540/fn/fn/fn         boot_jar2bin.clj:   90
           adzerk.boot-jar2bin/eval540/fn/fn/fn/fn         boot_jar2bin.clj:   91
adzerk.boot-jar2bin.launch4j/write-launch4j-config             launch4j.clj:   53
                                               ...
                             clojure.data.xml/emit                  xml.clj:  366
                             clojure.data.xml/emit                  xml.clj:  375
            clojure.data.xml/check-stream-encoding                  xml.clj:  362
       java.lang.Exception: Output encoding of stream (UTF-8) doesn't match declaration (Cp1252)
clojure.lang.ExceptionInfo: Output encoding of stream (UTF-8) doesn't match declaration (Cp1252)
    line: 124
```

Solution from here:
https://stackoverflow.com/questions/25478386/data-xml-output-encoding-of-stream-utf-8-doesnt-match-declaration-cp1252/25480763

Let me know if you need something more :)